### PR TITLE
ポモドーロが更新された時のみ休憩時間用のタイマーを表示させたい

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -60,3 +60,9 @@ body {
   text-align: center;
   background-color: white;
 }
+
+#break-timer {
+  background-color: #96bb7c;
+  font-size: 30px;
+  text-align: center;
+}

--- a/app/views/pomodoro_timer/timer.html.erb
+++ b/app/views/pomodoro_timer/timer.html.erb
@@ -34,7 +34,7 @@
         clearInterval(timer1);
         $('#stp-btn').hide();
         $('#comp-btn').show();
-        Push.create('Push通知');
+        sessionStorage.count = 'present'
       } else {
         $('#minute').text(addZero(Math.floor(int/60)));
         $('#second').text(addZero(int % 60));

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,14 +1,14 @@
-<h1>やることリスト</h1>
 
 <div id="break-timer" style="display:none;">
-<span id="minute">00</span>:
-<span id="second">02</span>
+<span>休憩時間      </span>
+<span id="minute">05</span>:
+<span id="second">00</span>
 </div>
-
 
 <div>
-  <p>本日の実績 <%= current_user.pomodoros.where(created_at: Time.zone.now.all_day).count%>回</p>
+  <p class="pink" style="text-align: center; font-size: 60px;">本日の実績 <%= current_user.pomodoros.where(created_at: Time.zone.now.all_day).count%>回</p>
 </div>
+<h1>やることリスト</h1>
 
 <!-- タスク新規作成モーダルボタン -->
 <button type="button" class="btn lavender" data-toggle="modal" data-target="#exampleModalCenter">タスク新規作成</button>
@@ -67,8 +67,9 @@
 
 <script>
   $(function(){
+    
     var timer1;
-    if(){
+    if(sessionStorage.getItem('count')){
       $('#break-timer').show();
       $(window).on('load', function() {
         timer1 = setInterval(function(){
@@ -87,6 +88,7 @@
       int = parseInt(int);
       if(int <= -1) {
         clearInterval(timer1);
+        sessionStorage.clear();
         $('#break-timer').hide();
       } else {
         $('#minute').text(addZero(Math.floor(int/60)));

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -5,6 +5,7 @@
 <span id="second">02</span>
 </div>
 
+
 <div>
   <p>本日の実績 <%= current_user.pomodoros.where(created_at: Time.zone.now.all_day).count%>回</p>
 </div>


### PR DESCRIPTION
## 概要
ER図
[![Image from Gyazo](https://i.gyazo.com/be7235c21a935bef8d0458f5429d6961.png)](https://gyazo.com/be7235c21a935bef8d0458f5429d6961)

`tasks/index.html.erb`ページ上部にjavascriptで休憩時間用のタイマーを作成しました。
仕組みは同ページ下部のscriptタグの中に記載しております。

タイマーのHTML
あえて2秒に設定しています。本番時は5分にする予定です。
```
<div id="break-timer" style="display:none;">
<span id="minute">00</span>:
<span id="second">02</span>
</div>

```

タイマーの<script>タグの中のソースコード
```
<script>
  $(function(){
    var timer1;
    if(){
      $('#break-timer').show();
      $(window).on('load', function() {
        timer1 = setInterval(function(){
          countDown()
        }, 1000);
      });
    };

    function countDown() {
      var min = parseInt($('#minute').text());
      var sec = parseInt($('#second').text());
      tmWrite(min * 60 + sec - 1);
    };

    function tmWrite(int) {
      int = parseInt(int);
      if(int <= -1) {
        clearInterval(timer1);
        $('#break-timer').hide();
      } else {
        $('#minute').text(addZero(Math.floor(int/60)));
        $('#second').text(addZero(int % 60));
      };
    };

    function addZero(val) {
      if(val < 10) {
        val = '0' + val;
      }
      return val;
    }
  });
</script>
```

### 実装したいこと
- `pomodoro_timer#create`アクションからポモドーロインスタンスが作成され、`tasks/index.html.erb`にリダイレクトされた時にのみ休憩時間用のタイマーを表示させたいです。
- `$(window).on('load', function(){}`を使ってページ表示時にタイマーをスタートしたいです。
- top画面やその他のページから`tasks/index.html.erb`に遷移した場合はタイマーは`display: none;`のままにして置きたいです。

### 試したこと
javascript内でif文を使って条件を定義しようと試みましたが、インスタンスが生成されたタイミングでの条件定義は現実的ではないと考えています。
根本的に違う方法での実装が良いのかもしれないと考えていますが良い考えが思い付かなかったのでもし何かご意見を頂けたら幸いです。
